### PR TITLE
Update version.markdown

### DIFF
--- a/source/_components/version.markdown
+++ b/source/_components/version.markdown
@@ -40,7 +40,7 @@ beta:
   type: boolean
   default: false
 image:
-  description: The image you want to check against, this is only supported for `hassio`, see full list under.
+  description: The image you want to check against, this is only supported for `hassio` and `docker`, see full list under.
   required: false
   type: string
   default: default
@@ -51,7 +51,7 @@ source:
   default: local
 {% endconfiguration %}
 
-### {% linkable_title Supported images for Hassio %}
+### {% linkable_title Supported images for Hassio and Docker %}
 
 `default`, `qemux86`, `qemux86-64`, `qemuarm`, `qemuarm-64`, `intel-nuc`, `raspberrypi`, `raspberrypi2`, `raspberrypi3`, `raspberrypi3-64`, `tinker`, `odroid-c2`, `odroid-xu`
 


### PR DESCRIPTION
**Description:**
Added a `docker` option for `image`

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
